### PR TITLE
roller updates and markdown auto color

### DIFF
--- a/Assets/Editor/MarkdownInspector.cs
+++ b/Assets/Editor/MarkdownInspector.cs
@@ -43,6 +43,13 @@ public class MarkdownInspector : Editor
         // I definitley snatched this regex from online
 
         string output = input;
+
+        // colors
+        output = System.Text.RegularExpressions.Regex.Replace(output, @"\b(red)\b", "<color=red>$1</color>", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        output = System.Text.RegularExpressions.Regex.Replace(output, @"\b(blue)\b", "<color=blue>$1</color>", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        output = System.Text.RegularExpressions.Regex.Replace(output, @"\b(yellow)\b", "<color=yellow>$1</color>", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        output = System.Text.RegularExpressions.Regex.Replace(output, @"\b(green)\b", "<color=green>$1</color>", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
         output = System.Text.RegularExpressions.Regex.Replace(output, @"^#### (.+)$", "<b><size=12>$1</size></b>", System.Text.RegularExpressions.RegexOptions.Multiline); // H1
         output = System.Text.RegularExpressions.Regex.Replace(output, @"^### (.+)$", "<b><size=14>$1</size></b>", System.Text.RegularExpressions.RegexOptions.Multiline); // H2
         output = System.Text.RegularExpressions.Regex.Replace(output, @"^## (.+)$", "<b><size=16>$1</size></b>", System.Text.RegularExpressions.RegexOptions.Multiline); // H3

--- a/Assets/Prefabs/Enemies/Roller/README.md
+++ b/Assets/Prefabs/Enemies/Roller/README.md
@@ -3,10 +3,16 @@ The roller basically rolls along the ground from its start point to a waypoint.
 The roller cannot go up/down, only left/right.
 
 ## Gizmos
-- red line is the vision line. It looks for the player in that line.
-- Freeze On Hit Time is basically when the roller stops moving for a brief moment after getting hit
+- **red line** is the vision line. It looks for the player in that line.
+    - It shows a line gizmo, but we also check within a 45 degree angle.
+- **yellow dot** is the position the roller is chasing after (its always a distance behind the spot it saw the target) (only visible during attack)
+- **blue dots** are the Start Position & Waypoint. So the roller will move between the dots.
+
+## Config
 - Waypoint is the position the roller will move to. Once it reaches it, it will go back to start.
-- blue dots are the Start Position & Waypoint. So the roller will move between the dots.
+- Freeze On Hit Time is basically when the roller stops moving for a brief moment after getting hit
+- Max Distance From Patrol basically limits the roller to only chase the player a certain distance from its patrol points.
+    - when this happens, the roller will imediatley give up chase, even before reaching its "chase target"
 
 ## Combat
 - Moves left/right along from start point to waypoint
@@ -16,6 +22,7 @@ The roller cannot go up/down, only left/right.
     - It temporarily turns off collision so that it can "go through" the player
     - A configurable damage timer will start, that prevents damaging the player again
 - If player is not hit, it will return to normal speed
+- If it no longer sees the player while mid chase, it will continue the chase to the target location, then return to normal
 
 ## Visuals
 - We have Idle, Hit, and Die animations.

--- a/Assets/Prefabs/Enemies/Roller/Rolller Enemy.prefab
+++ b/Assets/Prefabs/Enemies/Roller/Rolller Enemy.prefab
@@ -191,7 +191,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.8, y: 0.6}
+  m_Size: {x: 0.8, y: 0.54}
   m_EdgeRadius: 0
 --- !u!50 &6522498738444393160
 Rigidbody2D:
@@ -237,7 +237,7 @@ MonoBehaviour:
   animator: {fileID: 5853518491072573498}
   healthComponent: {fileID: 5644258311082689311}
   speed: 2
-  chaseSpeed: 3.5
+  chaseSpeed: 5
   waypoint: {fileID: 0}
   damage: 1
   freezeOnHitTime: 0.3
@@ -261,7 +261,7 @@ MonoBehaviour:
   HealthBarBackground: {fileID: 3884401751897927832}
   HealthBarOffset: 1
   isBoss: 0
-  autoDestoryOnDeath: 0
+  autoDestroyOnDeath: 0
   maxHealth: 1
   bossType: 0
   dieEvent:

--- a/Assets/Prefabs/Enemies/Thwomper/README.md
+++ b/Assets/Prefabs/Enemies/Thwomper/README.md
@@ -5,8 +5,8 @@ it will shove the player out of the way. The Thwomper is only damagable while on
 Thwomper will wait a specified time before going back into the air.
 
 ## Gizmos
-- red line is line of sight
-- blue dots are the start position and waypoint (what it walks between)
+- **red** line is line of sight
+- **blue** dots are the start position and waypoint (what it walks between)
 
 ## Combat
 - Uses a raycast down to check for the player

--- a/Assets/Scripts/Enemies/Roller/RollerEnemy.cs
+++ b/Assets/Scripts/Enemies/Roller/RollerEnemy.cs
@@ -23,6 +23,7 @@ public class RollerEnemy : MonoBehaviour
     [SerializeField] private LayerMask visionMask;
     [Tooltip("The time in seconds we are to wait before allowing a hit on the target again.")]
     [SerializeField, Min(0f)] private float attackBuffer = 1f;
+    [SerializeField, Min(0f)] private float maxDistanceFromPatrol = 4f;
 
     private Transform target;
     private Vector2 startPosition = Vector2.zero;
@@ -31,10 +32,13 @@ public class RollerEnemy : MonoBehaviour
     private float hitTime = 0f;
     private bool dead = false;
     private bool targetInSight = false;
+    private Vector2 lastKnownTargetPosition = Vector2.zero;
     private float lastTimeHitPlayer = 0f; // this the time we hit the player, not the player attacking us
 
     private const float WAYPOINT_PROXIMITY = 0.1f;
     private const float DEATH_DESTROY_TIME = 0.5f;
+    private const float OVER_ROLL_DISTANCE = 2f;
+    private const float VISION_ANGLE = 45f;
 
     private const string IDLE_ANIM = "Idle";
     private const string HIT_ANIM = "Hit";
@@ -67,11 +71,12 @@ public class RollerEnemy : MonoBehaviour
     {
         if (moveDirection != Vector2.zero)
             UpdateSpriteDirection(moveDirection);
-        
+
         if (moveDirection != Vector2.zero)
         {
-            var visionHit = Physics2D.Raycast(rb.position, moveDirection, visionRange, visionMask);
-            targetInSight = visionHit.collider != null && visionHit.collider.CompareTag(target.tag);
+            targetInSight = CheckVision();
+            if (targetInSight)
+                lastKnownTargetPosition = (Vector2)target.position;
         }
 
         if (hitTime != 0f && Time.time - hitTime > freezeOnHitTime)
@@ -89,32 +94,88 @@ public class RollerEnemy : MonoBehaviour
         if (hitTime != 0f || dead)
             return;
 
-        Vector2 targetPosition = (movingTowardsWaypoint) ? (Vector2)waypoint.position : startPosition;
-        if (NearPosition(targetPosition))
+        if (lastKnownTargetPosition != Vector2.zero)
         {
-            movingTowardsWaypoint = !movingTowardsWaypoint;
-            targetPosition = (movingTowardsWaypoint) ? waypoint.position : startPosition;
+            // make sure cap movement from our patrol point
+            if (DistanceOutsidePatrolPoints() > maxDistanceFromPatrol)
+            {
+                lastKnownTargetPosition = Vector2.zero;
+            }
+            else
+            {
+                // calculate the position to roll at (past the player)
+                Vector2 targetPosition = lastKnownTargetPosition + (moveDirection * OVER_ROLL_DISTANCE);
+                if (NearPosition(targetPosition))
+                {
+                    // we hit our target position, turn around and check for the player
+                    moveDirection.x *= -1;
+                    targetInSight = CheckVision();
+                    lastKnownTargetPosition = (targetInSight) ? (Vector2)target.position : Vector2.zero;
+                }
+                else
+                    rb.linearVelocity = new Vector2(moveDirection.x * chaseSpeed, rb.linearVelocity.y);
+            }
         }
+        else
+        {
+            // move to waypoint
+            Vector2 targetPosition = (movingTowardsWaypoint) ? (Vector2)waypoint.position : startPosition;
+            if (NearPosition(targetPosition))
+            {
+                movingTowardsWaypoint = !movingTowardsWaypoint;
+                targetPosition = (movingTowardsWaypoint) ? waypoint.position : startPosition;
+            }
 
-        moveDirection = (targetPosition - rb.position).normalized;
-        moveDirection.y = 0f;
+            moveDirection = (targetPosition - rb.position).normalized;
+            moveDirection.y = 0f;
 
-        float movementSpeed = (targetInSight || lastTimeHitPlayer != 0f) ? chaseSpeed : speed;
-
-        rb.linearVelocity = new Vector2(moveDirection.x * movementSpeed, rb.linearVelocity.y);
+            rb.linearVelocity = new Vector2(moveDirection.x * speed, rb.linearVelocity.y);
+        }
     }
 
     private void OnCollisionEnter2D(Collision2D collision)
     {
         if (dead || lastTimeHitPlayer > 0f)
             return;
-        
+
         if (collision.gameObject.CompareTag(target.tag))
         {
             Player.Instance.health.TakeDamage(damage, false);
             lastTimeHitPlayer = Time.time;
             col.excludeLayers |= 1 << target.gameObject.layer;
         }
+    }
+
+    private bool CheckVision()
+    {
+        bool sawTarget = false;
+        Vector2 directionToTarget = ((Vector2)target.position - rb.position).normalized;
+        if (Mathf.Sign(directionToTarget.x) == Mathf.Sign(moveDirection.x))
+        {
+            float distanceToTarget = Vector2.Distance(rb.position, (Vector2)target.position);
+            if (distanceToTarget <= visionRange)
+            {
+                float angleToTarget = Vector2.Angle(moveDirection, directionToTarget);
+                if (angleToTarget < VISION_ANGLE * 0.5f)
+                {
+                    var visionHit = Physics2D.Raycast(rb.position, directionToTarget, visionRange, visionMask);
+                    sawTarget = visionHit.collider != null && visionHit.collider.CompareTag(target.tag);
+                }
+            }
+        }
+        return sawTarget;
+    }
+
+    private float DistanceOutsidePatrolPoints()
+    {
+        // if we are in between the patrol points, just return 0
+        var leftPosition = (startPosition.x < waypoint.position.x) ? startPosition.x : waypoint.position.x;
+        var rightPosition = (startPosition.x > waypoint.position.x) ? startPosition.x : waypoint.position.x;
+        if (rb.position.x >= leftPosition && rb.position.x <= rightPosition)
+            return 0f;
+
+        var targetPosition = (moveDirection.x > 0) ? rightPosition : leftPosition;
+        return Mathf.Abs(rb.position.x - targetPosition);
     }
 
     private bool NearPosition(Vector2 targetPosition)
@@ -151,6 +212,15 @@ public class RollerEnemy : MonoBehaviour
         Gizmos.color = Color.red;
         Vector2 direction = moveDirection != Vector2.zero ? moveDirection : Vector2.right;
         Gizmos.DrawLine(rb.position, rb.position + direction * visionRange);
+
+        if (lastKnownTargetPosition != Vector2.zero)
+        {
+            // Gizmos.color = Color.red;
+            // Gizmos.DrawSphere(lastKnownTargetPosition, 0.1f);
+
+            Gizmos.color = Color.yellow;
+            Gizmos.DrawSphere(lastKnownTargetPosition + moveDirection * OVER_ROLL_DISTANCE, 0.1f);
+        }
 
         if (waypoint != null)
         {


### PR DESCRIPTION
Fix the following bugs
- updated roller to speed through the player and then turn around and try again
- now once a chase is started, continue the chase until it reaches it the previous target
- added support for "out of bounds" so it does not leave patrol points by too much
- added cone vision checks (still renders as a line gizmo though)
- fixed roller prefab so the art sits on the ground

Also updated markdown inspector to auto color some color words.